### PR TITLE
Add shake animation to dice roll via CSS class

### DIFF
--- a/dice-game/index.js
+++ b/dice-game/index.js
@@ -1,21 +1,36 @@
-var randomNumber1 = Math.floor(Math.random() * 6 + 1); 
-var randomDiceImage = "images/dice" + randomNumber1 + ".png";
 
-var image1 = document.querySelector(".img1"); 
-image1.setAttribute("src", randomDiceImage); 
 
-var randomNumber2 = Math.floor(Math.random() * 6 + 1); 
-var randomImageSource2 = "images/dice" + randomNumber2 + ".png"; 
+const rollDice = () => {
+    const image1 = document.querySelector(".img1");
+    const image2 = document.querySelector(".img2");
 
-var image2 = document.querySelector(".img2"); 
-image2.setAttribute("src", randomImageSource2); 
+    const msg = document.querySelector(".display-msg");
+    image1.classList.add("shake");
+    image2.classList.add("shake");
+    
+    setTimeout(() => {
+        const randomNumber1 = Math.floor(Math.random() * 6 + 1);
+        const randomNumber2 = Math.floor(Math.random() * 6 + 1);
 
-var msg = document.querySelector(".display-msg");
+        image1.setAttribute("src", "images/dice" + randomNumber1 + ".png");
+        image2.setAttribute("src", "images/dice" + randomNumber2 + ".png");
 
-if (randomNumber1 > randomNumber2) {
-    msg.innerHTML = "Player 1 wins!";
-} else if (randomNumber2 > randomNumber1) {
-    msg.innerHTML = "Player 2 wins!";
-} else {
-    msg.innerHTML = "It's a draw!";
+        if (randomNumber1 > randomNumber2) {
+            msg.innerHTML = "Player 1 wins!";
+        } else if (randomNumber2 > randomNumber1) {
+            msg.innerHTML = "Player 2 wins!";
+        } else {
+            msg.innerHTML = "It's a draw!";
+        }
+
+        image1.classList.remove("shake");
+        image2.classList.remove("shake");  
+
+
+    }, 400);
 }
+window.onload = () => {
+    setTimeout(() => {
+        rollDice();
+    }, 500);
+};

--- a/dice-game/styles.css
+++ b/dice-game/styles.css
@@ -64,3 +64,20 @@ footer {
   justify-content: center;
   align-items: center;
 }
+@keyframes shake {
+  0%   { transform: translate(0, 0) rotate(0deg); }
+  10%  { transform: translate(-2px, -2px) rotate(-3deg); }
+  20%  { transform: translate(2px, -1px) rotate(3deg); }
+  30%  { transform: translate(-1px, 2px) rotate(-2deg); }
+  40%  { transform: translate(2px, 1px) rotate(2deg); }
+  50%  { transform: translate(-2px, -1px) rotate(-3deg); }
+  60%  { transform: translate(1px, 2px) rotate(2deg); }
+  70%  { transform: translate(-1px, -2px) rotate(-1deg); }
+  80%  { transform: translate(2px, 1px) rotate(1deg); }
+  90%  { transform: translate(-2px, -1px) rotate(-2deg); }
+  100% { transform: translate(0, 0) rotate(0deg); }
+}
+
+.shake {
+  animation: shake 0.6s ease-in-out;
+}


### PR DESCRIPTION
This PR adds a short shake animation to both dice before showing the result, to simulate the feeling of a real dice roll.
Changes include:
* Wrapping the dice update logic in a setTimeout to delay image changes.
* Adding a shake CSS class to both dice images before the roll.
* Removing the class after a short delay.
* Creating a .shake class in the CSS to handle the animation.